### PR TITLE
Bring in the Operator framework as a submodule.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,1 @@
-lib/ops
-lib/ops-*.dist-info
-lib/ops-*.egg-info
 .idea

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "mod/operator"]
+	path = mod/operator
+	url = https://github.com/canonical/operator

--- a/README.md
+++ b/README.md
@@ -1,13 +1,7 @@
 GitLab Charm for Kubernetes Models
 ==================================
 
-To use, first install the framework using pip:
-
-```bash
-pip install -t lib/ https://github.com/canonical/operator
-```
-
-Then deploy the charm with an appropriate image resource:
+To use, deploy the charm with an appropriate image resource:
 
 ```bash
 docker pull gitlab/gitlab-ce:12.0.12-ce.0

--- a/lib/ops
+++ b/lib/ops
@@ -1,0 +1,1 @@
+../mod/operator/ops


### PR DESCRIPTION
Add mod/operator pointing at https://github.com/canonical/operator and
symlink the 'ops' directory from lib (rather than ignoring a pip
installed version).